### PR TITLE
Linkify highlighted code

### DIFF
--- a/holborn-web/default.nix
+++ b/holborn-web/default.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, basic-prelude, blaze-html, highlighter2
-, Spock, stdenv, tasty, tasty-hunit, text
+{ mkDerivation, base, basic-prelude, blaze-html, bytestring
+, highlighter2, Spock, stdenv, tasty, tasty-hunit, text
 }:
 mkDerivation {
   pname = "holborn-web";
@@ -8,7 +8,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   buildDepends = [
-    base basic-prelude blaze-html highlighter2 Spock text
+    base basic-prelude blaze-html bytestring highlighter2 Spock text
   ];
   testDepends = [ base basic-prelude tasty tasty-hunit ];
   homepage = "https://github.com/jml/holborn";

--- a/holborn-web/holborn-web.cabal
+++ b/holborn-web/holborn-web.cabal
@@ -15,9 +15,11 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Holborn.Web
                      , Holborn.Style
+                     , Holborn.HtmlFormat
   build-depends:       base >=4.8 && <4.9
                        -- We want basic-prelude 0.4.0, but it's not in Nix yet.
                      , basic-prelude >= 0.3.13 && <0.6
+                     , bytestring >= 0.10 && <0.11
                      , highlighter2 >= 0.2 && <0.3
                      , blaze-html >= 0.8 && <0.9
                      , text >= 1.2 && <1.3

--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -2,9 +2,8 @@
 
 module Holborn.HtmlFormat (format, formatInline) where
 
-import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8)
-import Prelude hiding (div, span)
+import BasicPrelude hiding (div, span)
+
 import Text.Blaze.Html5
 import Text.Blaze.Html5.Attributes hiding (span)
 import qualified Data.ByteString as BS

--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -1,0 +1,56 @@
+{- | Adapted version of highlighter2 syntax highlighter.  -}
+
+module Holborn.HtmlFormat (format, formatInline) where
+
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Prelude hiding (div, span)
+import Text.Blaze.Html5
+import Text.Blaze.Html5.Attributes hiding (span)
+import qualified Data.ByteString as BS
+
+import Text.Highlighter.Types
+
+
+format :: Bool -> [Token] -> Html
+format ls ts
+    | ls =
+        table ! class_ "highlighttable" $ tr $ do
+            td ! class_ "linenos" $
+                div ! class_ "linenodiv" $
+                    pre (lineNos (countLines ts))
+
+            td ! class_ "code" $
+                div ! class_ "highlight" $
+                    pre $ highlight ts
+    | otherwise =
+        div ! class_ "highlight" $
+            pre $ highlight ts
+
+formatInline :: [Token] -> Html
+formatInline = code . highlight
+
+highlight :: [Token] -> Html
+highlight [] = return ()
+highlight (Token t s:ts) = do
+    span ! class_ (toValue $ shortName t) $ toHtml (decodeUtf8 s)
+    highlight ts
+
+countLines :: [Token] -> Int
+countLines [] = 0
+countLines (Token _ s:ts) =
+    length (BS.elemIndices (toEnum . fromEnum $ '\n') s) + countLines ts
+
+lineNos :: Int -> Html
+lineNos n = lineNos' 1
+  where
+    lineNos' c
+        | c <= n = do
+            a ! href (toValue $ "#L-" ++ show c)
+              ! name (toValue $ "L-" ++ show c) $
+                toHtml (show c)
+
+            toHtml ("\n" :: Text)
+
+            lineNos' (c + 1)
+        | otherwise = return ()

--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -27,14 +27,21 @@ format ls ts
         H.div ! A.class_ "highlight" $
             H.pre $ highlight ts
 
+
 formatInline :: [Token] -> Html
 formatInline = H.code . highlight
 
+
+highlightToken :: Token -> Html
+highlightToken (Token t s) = H.span ! A.class_ (H.toValue $ shortName t) $ H.toHtml (decodeUtf8 s)
+
+
 highlight :: [Token] -> Html
 highlight [] = return ()
-highlight (Token t s:ts) = do
-    H.span ! A.class_ (H.toValue $ shortName t) $ H.toHtml (decodeUtf8 s)
-    highlight ts
+highlight (token:tokens) = do
+    highlightToken token
+    highlight tokens
+
 
 countLines :: [Token] -> Int
 countLines [] = 0

--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -33,9 +33,51 @@ formatInline = H.code . highlight
 
 
 highlightToken :: Token -> Html
-highlightToken (Token t s) = H.span ! A.class_ (H.toValue $ shortName t) $ H.toHtml (decodeUtf8 s)
+highlightToken token@(Token t s) =
+  if isReference token
+  then H.a ! A.href (H.toValue ("https://google.com/#safe=strict&q=" ++ decodeUtf8 s)) $ baseToken
+  else baseToken
+  where
+    baseToken = H.span ! A.class_ (H.toValue $ shortName t) $ H.toHtml (decodeUtf8 s)
 
 
+-- | Is this given token a reference to a thing with a definition?
+--
+-- We use this to decide whether to linkify things or not.
+--
+-- XXX: Probably should return a richer data type, e.g. Reference | Value
+isReference :: Token -> Bool
+isReference (Token t _) =
+  -- XXX: These aren't empirically verified to be actual references, it's just
+  -- a first guess.
+  case t of
+    Declaration   -> True
+    Reserved      -> True
+    Type          -> True
+    Pseudo        -> True
+    Namespace     -> True
+    Class         -> True
+    Constant      -> True
+    Attribute     -> True
+    Builtin       -> True
+    Decorator     -> True
+    Entity        -> True
+    Exception     -> True
+    Function      -> True
+    Identifier    -> True
+    Label         -> True
+    Property      -> True
+    Tag           -> True
+    Variable      -> True
+    Global        -> True
+    Instance      -> True
+    Anonymous     -> True
+    Arbitrary "Name"      -> True
+    Arbitrary "Name" :. _ -> True
+    _ -> False
+
+
+-- XXX: This is just a fold.
 highlight :: [Token] -> Html
 highlight [] = return ()
 highlight (token:tokens) = do

--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -4,8 +4,9 @@ module Holborn.HtmlFormat (format, formatInline) where
 
 import BasicPrelude hiding (div, span)
 
-import Text.Blaze.Html5
-import Text.Blaze.Html5.Attributes hiding (span)
+import Text.Blaze.Html5 (Html, (!))
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
 import qualified Data.ByteString as BS
 
 import Text.Highlighter.Types
@@ -14,25 +15,25 @@ import Text.Highlighter.Types
 format :: Bool -> [Token] -> Html
 format ls ts
     | ls =
-        table ! class_ "highlighttable" $ tr $ do
-            td ! class_ "linenos" $
-                div ! class_ "linenodiv" $
-                    pre (lineNos (countLines ts))
+        H.table ! A.class_ "highlighttable" $ H.tr $ do
+            H.td ! A.class_ "linenos" $
+                H.div ! A.class_ "linenodiv" $
+                    H.pre (lineNos (countLines ts))
 
-            td ! class_ "code" $
-                div ! class_ "highlight" $
-                    pre $ highlight ts
+            H.td ! A.class_ "code" $
+                H.div ! A.class_ "highlight" $
+                    H.pre $ highlight ts
     | otherwise =
-        div ! class_ "highlight" $
-            pre $ highlight ts
+        H.div ! A.class_ "highlight" $
+            H.pre $ highlight ts
 
 formatInline :: [Token] -> Html
-formatInline = code . highlight
+formatInline = H.code . highlight
 
 highlight :: [Token] -> Html
 highlight [] = return ()
 highlight (Token t s:ts) = do
-    span ! class_ (toValue $ shortName t) $ toHtml (decodeUtf8 s)
+    H.span ! A.class_ (H.toValue $ shortName t) $ H.toHtml (decodeUtf8 s)
     highlight ts
 
 countLines :: [Token] -> Int
@@ -45,11 +46,11 @@ lineNos n = lineNos' 1
   where
     lineNos' c
         | c <= n = do
-            a ! href (toValue $ "#L-" ++ show c)
-              ! name (toValue $ "L-" ++ show c) $
-                toHtml (show c)
+            H.a ! A.href (H.toValue $ "#L-" ++ show c)
+                ! A.name (H.toValue $ "L-" ++ show c) $
+              H.toHtml (show c)
 
-            toHtml ("\n" :: Text)
+            H.toHtml ("\n" :: Text)
 
             lineNos' (c + 1)
         | otherwise = return ()

--- a/holborn-web/lib/Holborn/Web.hs
+++ b/holborn-web/lib/Holborn/Web.hs
@@ -14,11 +14,11 @@ import Text.Blaze.Html5 ((!))
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
-import Text.Highlighter.Formatters.Html (format)
 import Text.Highlighter.Lexer (runLexer)
 import Text.Highlighter.Lexers (lexers)
 import Text.Highlighter.Types (Token)
 
+import Holborn.HtmlFormat (format)
 import Holborn.Style (monokai)
 
 


### PR DESCRIPTION
Deliberately stupid attempt to linkify source code.

Has a first-pass attempt at identifying references based on lexer information. All references are wrapped in an `a` tag and linked to a Google search for the term.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jml/holborn/8)
<!-- Reviewable:end -->
