### PR TITLE
Wire annotations through to syntax highlighter

### DIFF
--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -77,18 +77,15 @@ isReference (Token t _) =
     _ -> False
 
 
--- XXX: This is just a fold.
 highlight :: [Token] -> Html
-highlight [] = return ()
-highlight (token:tokens) = do
-    highlightToken token
-    highlight tokens
+highlight = mconcat . map highlightToken
 
 
 countLines :: [Token] -> Int
-countLines [] = 0
-countLines (Token _ s:ts) =
-    length (BS.elemIndices (toEnum . fromEnum $ '\n') s) + countLines ts
+countLines = sum . map linesInToken
+  where linesInToken (Token _ s) = length $ BS.elemIndices newlineByte s
+        newlineByte = 0xA  -- '\n'
+
 
 lineNos :: Int -> Html
 lineNos n = lineNos' 1

--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -42,17 +42,12 @@ formatInline = H.code . highlight
 
 highlightToken :: HolbornToken -> Html
 highlightToken token =
-  -- XXX: We now have two things that can indicate whether something is a
-  -- reference: it can have a reference-like token type, or it can have a
-  -- Reference associated with it. Not clear what we should do when we have
-  -- one and not the other. I guess warn?
-  if isReference token
-  then H.a ! A.href (H.toValue tokenUrl) $ baseToken
-  else baseToken
+  case getUrl token of
+    Nothing -> baseToken
+    Just tokenUrl -> H.a ! A.href (H.toValue tokenUrl) $ baseToken
   where
     baseToken = H.span ! A.class_ (H.toValue . shortName . tokenType $ token) $ H.toHtml contents
     contents = decodeUtf8 (tokenName token)
-    tokenUrl = fromMaybe ("https://google.com/#safe=strict&q=" ++ contents) (getUrl token)
 
 
 -- XXX: I guess theoretically we should be able to get the URL just from the
@@ -69,42 +64,6 @@ tokenReference' token =
     r'@(Reference r)
       | r == "" -> Nothing
       | otherwise -> Just r'
-
-
--- | Is this given token a reference to a thing with a definition?
---
--- We use this to decide whether to linkify things or not.
---
--- XXX: Probably should return a richer data type, e.g. Reference | Value
-isReference :: HolbornToken -> Bool
-isReference token =
-  -- XXX: These aren't empirically verified to be actual references, it's just
-  -- a first guess.
-  case tokenType token of
-    Declaration   -> True
-    Reserved      -> True
-    Type          -> True
-    Pseudo        -> True
-    Namespace     -> True
-    Class         -> True
-    Constant      -> True
-    Attribute     -> True
-    Builtin       -> True
-    Decorator     -> True
-    Entity        -> True
-    Exception     -> True
-    Function      -> True
-    Identifier    -> True
-    Label         -> True
-    Property      -> True
-    Tag           -> True
-    Variable      -> True
-    Global        -> True
-    Instance      -> True
-    Anonymous     -> True
-    Arbitrary "Name"      -> True
-    Arbitrary "Name" :. _ -> True
-    _ -> False
 
 
 highlight :: [HolbornToken] -> Html

--- a/holborn-web/lib/Holborn/HtmlFormat.hs
+++ b/holborn-web/lib/Holborn/HtmlFormat.hs
@@ -11,8 +11,10 @@ import qualified Data.ByteString as BS
 
 import Text.Highlighter.Types
 
+import Holborn.Types (HolbornToken(..))
 
-format :: Bool -> [Token] -> Html
+
+format :: Bool -> [HolbornToken] -> Html
 format ls ts
     | ls =
         H.table ! A.class_ "highlighttable" $ H.tr $ do
@@ -28,12 +30,12 @@ format ls ts
             H.pre $ highlight ts
 
 
-formatInline :: [Token] -> Html
+formatInline :: [HolbornToken] -> Html
 formatInline = H.code . highlight
 
 
-highlightToken :: Token -> Html
-highlightToken token@(Token t s) =
+highlightToken :: HolbornToken -> Html
+highlightToken token@(HolbornToken (Token t s) _) =
   if isReference token
   then H.a ! A.href (H.toValue ("https://google.com/#safe=strict&q=" ++ decodeUtf8 s)) $ baseToken
   else baseToken
@@ -46,8 +48,8 @@ highlightToken token@(Token t s) =
 -- We use this to decide whether to linkify things or not.
 --
 -- XXX: Probably should return a richer data type, e.g. Reference | Value
-isReference :: Token -> Bool
-isReference (Token t _) =
+isReference :: HolbornToken -> Bool
+isReference (HolbornToken (Token t _) _) =
   -- XXX: These aren't empirically verified to be actual references, it's just
   -- a first guess.
   case t of
@@ -77,13 +79,13 @@ isReference (Token t _) =
     _ -> False
 
 
-highlight :: [Token] -> Html
+highlight :: [HolbornToken] -> Html
 highlight = mconcat . map highlightToken
 
 
-countLines :: [Token] -> Int
+countLines :: [HolbornToken] -> Int
 countLines = sum . map linesInToken
-  where linesInToken (Token _ s) = length $ BS.elemIndices newlineByte s
+  where linesInToken (HolbornToken (Token _ s) _) = length $ BS.elemIndices newlineByte s
         newlineByte = 0xA  -- '\n'
 
 

--- a/holborn-web/lib/Holborn/Types.hs
+++ b/holborn-web/lib/Holborn/Types.hs
@@ -9,9 +9,14 @@ import BasicPrelude
 import Text.Highlighter.Types (Token)
 
 -- | A token with extra semantic information. More data to be added later.
-data Reference = Reference Text
 data HolbornToken = HolbornToken Token Reference
 
--- | Placeholder data structure for AST
+-- | Opaque data type representing the location of a token in our yet-to-be-
+-- defined semantic data structure.
+data Reference = Reference Text
+
+-- | An identifier found in code.
 data Symbol = Symbol ByteString Reference
+
+-- | Placeholder data structure for AST
 data Annotation = Annotation [Symbol]

--- a/holborn-web/lib/Holborn/Types.hs
+++ b/holborn-web/lib/Holborn/Types.hs
@@ -3,10 +3,13 @@ module Holborn.Types
        , Annotation(..)
        , Reference(..)
        , HolbornToken(..)
+       , tokenName
+       , tokenReference
+       , tokenType
        ) where
 
 import BasicPrelude
-import Text.Highlighter.Types (Token)
+import Text.Highlighter.Types (Token(..), TokenType)
 
 -- | A token with extra semantic information. More data to be added later.
 data HolbornToken = HolbornToken Token Reference
@@ -16,7 +19,21 @@ data HolbornToken = HolbornToken Token Reference
 data Reference = Reference Text
 
 -- | An identifier found in code.
+-- XXX: Maybe rename to Identifier?
 data Symbol = Symbol ByteString Reference
 
 -- | Placeholder data structure for AST
+-- XXX: This doesn't represent an AST any more. What *does* it represent?
 data Annotation = Annotation [Symbol]
+
+
+tokenType :: HolbornToken -> TokenType
+tokenType (HolbornToken (Token t _) _) = t
+
+
+tokenName :: HolbornToken -> ByteString
+tokenName (HolbornToken (Token _ s) _) = s
+
+
+tokenReference :: HolbornToken -> Reference
+tokenReference (HolbornToken _ r) = r

--- a/holborn-web/lib/Holborn/Types.hs
+++ b/holborn-web/lib/Holborn/Types.hs
@@ -12,6 +12,7 @@ import BasicPrelude
 import Text.Highlighter.Types (Token(..), TokenType)
 
 -- | A token with extra semantic information. More data to be added later.
+-- XXX: Should probably be (Maybe Reference), since we don't always know.
 data HolbornToken = HolbornToken Token Reference
 
 -- | Opaque data type representing the location of a token in our yet-to-be-

--- a/holborn-web/lib/Holborn/Web.hs
+++ b/holborn-web/lib/Holborn/Web.hs
@@ -23,9 +23,6 @@ import Holborn.HtmlFormat (format)
 import Holborn.Style (monokai)
 import Holborn.Types (Annotation(..), Symbol(..), HolbornToken(..), Reference(..))
 
--- | Get a token that can be fed into our highlighting library.
-getHighlightingToken :: HolbornToken -> Token
-getHighlightingToken (HolbornToken t _) = t
 
 annotateTokens :: [Token] -> Annotation -> [HolbornToken]
 -- left merge
@@ -38,9 +35,9 @@ annotateTokens (x:xs) (Annotation []) = (HolbornToken x (Reference "")) : annota
 
 annotateTokens _ _ = terror "Could not match AST data to tokenized data"
 
+
 formatHtmlBlock :: [HolbornToken] -> Html
-formatHtmlBlock tokens =
-  format includeLineNumbers (map getHighlightingToken tokens)
+formatHtmlBlock = format includeLineNumbers
   where includeLineNumbers = False
 
 


### PR DESCRIPTION
If we have a Reference, link to it, otherwise Google search.

Please pay attention to XXX comments.

- change the type in the highlighter to HolbornToken
- add an abstraction layer for the core types
- simplify implementations of some internal methods

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jml/holborn/10)
<!-- Reviewable:end -->
