### PR TITLE
Analyze Python in Haskell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 # From https://github.com/hvr/multi-ghc-travis
 
 env:
- - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=1.22 GHCVER=7.10.1 HAPPYVER=1.19.5 ALEXVER=3.1.4
 
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER happy-$HAPPYVER alex-$ALEXVER
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER happy-$HAPPYVER alex-$ALEXVER
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$PATH
 
 install:
  - cabal --version

--- a/holborn-web/default.nix
+++ b/holborn-web/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, base, basic-prelude, blaze-html, bytestring
-, highlighter2, Spock, stdenv, tasty, tasty-hunit, tasty-quickcheck
-, text
+, containers, highlighter2, language-python, mtl, pretty-show
+, Spock, stdenv, tasty, tasty-hunit, tasty-quickcheck, text
 }:
 mkDerivation {
   pname = "holborn-web";
@@ -9,7 +9,8 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   buildDepends = [
-    base basic-prelude blaze-html bytestring highlighter2 Spock text
+    base basic-prelude blaze-html bytestring containers highlighter2
+    language-python mtl pretty-show Spock text
   ];
   testDepends = [
     base basic-prelude tasty tasty-hunit tasty-quickcheck

--- a/holborn-web/holborn-web.cabal
+++ b/holborn-web/holborn-web.cabal
@@ -17,12 +17,18 @@ library
                      , Holborn.Style
                      , Holborn.HtmlFormat
                      , Holborn.Types
+                     , Holborn.Scope
+                     , Holborn.Python
   build-depends:       base >=4.8 && <4.9
                      , basic-prelude >= 0.5 && <0.6
                      , highlighter2 >= 0.2 && <0.3
                      , blaze-html >= 0.8 && <0.9
                      , text >= 1.2 && <1.3
                      , bytestring >= 0.10 && <0.11
+                     , language-python >= 0.5.0 && <0.6
+                     , containers >= 0.5 && <0.6
+                     , mtl >= 2.2 && <2.3
+                     , pretty-show
   hs-source-dirs:      lib
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/holborn-web/lib/Holborn/Python.hs
+++ b/holborn-web/lib/Holborn/Python.hs
@@ -18,8 +18,7 @@ import Language.Python.Common.Token (tokenString)
 import Language.Python.Version2.Lexer (lex)
 import Language.Python.Version2.Parser (parseModule)
 
-import Holborn.Scope ( Annotation
-                     , Scoped
+import Holborn.Scope ( Scoped
                      , ID
                      , addReference
                      , bind
@@ -29,6 +28,7 @@ import Holborn.Scope ( Annotation
                      , pushScope
                      , popScope
                      )
+import Holborn.Types (Annotation)
 
 
 getAST :: Text -> FilePath -> Either ParseError (Module SrcSpan, [Token])

--- a/holborn-web/lib/Holborn/Python.hs
+++ b/holborn-web/lib/Holborn/Python.hs
@@ -3,6 +3,7 @@ module Holborn.Python (annotateSourceCode, getAST, Token) where
 import BasicPrelude hiding (lex)
 
 import qualified Data.Map as M
+import Data.Text (pack)
 import Language.Python.Common ( Argument(..)
                               , Expr(..)
                               , Ident(..)
@@ -48,11 +49,11 @@ annotateSourceCode sourceCode = do
 
 
 bindIdent :: Ident a -> Scoped a ()
-bindIdent (Ident name srcSpan) = void (bind name srcSpan)
+bindIdent (Ident name srcSpan) = void (bind (pack name) srcSpan)
 
 
 addReferenceIdent :: Ident a -> Scoped a ()
-addReferenceIdent (Ident name srcSpan) = addReference name srcSpan
+addReferenceIdent (Ident name srcSpan) = addReference (pack name) srcSpan
 
 
 calculateAnnotations :: Module SrcSpan -> [Token] -> [(String, Maybe (Annotation ID))]

--- a/holborn-web/lib/Holborn/Python.hs
+++ b/holborn-web/lib/Holborn/Python.hs
@@ -1,0 +1,122 @@
+module Holborn.Python (annotateSourceCode, getAST, Token) where
+
+import BasicPrelude hiding (lex)
+
+import qualified Data.Map as M
+import Language.Python.Common ( Argument(..)
+                              , Expr(..)
+                              , Ident(..)
+                              , Parameter(..)
+                              , ParamTuple(..)
+                              , ParseError
+                              , Module(..)
+                              , SrcSpan
+                              , Statement(..)
+                              , Token(token_span)
+                              )
+import Language.Python.Common.Token (tokenString)
+import Language.Python.Version2.Lexer (lex)
+import Language.Python.Version2.Parser (parseModule)
+
+import Holborn.Scope ( Annotation
+                     , Scoped
+                     , ID
+                     , addReference
+                     , bind
+                     , execScoped
+                     , flattenScope
+                     , newScope
+                     , pushScope
+                     , popScope
+                     )
+
+
+getAST :: Text -> FilePath -> Either ParseError (Module SrcSpan, [Token])
+getAST sourceCode = parseModule (textToString sourceCode)
+
+
+getTokens :: Text -> FilePath -> Either ParseError [Token]
+getTokens sourceCode = lex (textToString sourceCode)
+
+
+annotateSourceCode :: Text -> Either ParseError [(String, Maybe (Annotation ID))]
+annotateSourceCode sourceCode = do
+  (ast, _) <- getAST sourceCode filename
+  tokens <- getTokens sourceCode filename
+  return $ calculateAnnotations ast tokens
+  where filename = "<stdin>"
+
+
+bindIdent :: Ident a -> Scoped a ()
+bindIdent (Ident name srcSpan) = void (bind name srcSpan)
+
+
+addReferenceIdent :: Ident a -> Scoped a ()
+addReferenceIdent (Ident name srcSpan) = addReference name srcSpan
+
+
+calculateAnnotations :: Module SrcSpan -> [Token] -> [(String, Maybe (Annotation ID))]
+calculateAnnotations moduleSpan tokens =
+  [(ts, M.lookup (token_span t) flattened) | t <- tokens, let ts = tokenString t, not (null ts)]
+  where
+    flattened = flattenScope $ execScoped (interpret moduleSpan) newScope
+
+
+interpret :: Module a -> Scoped a ()
+interpret (Module statements) = mapM_ interpretStatement statements
+
+interpretStatement :: Statement a -> Scoped a ()
+-- XXX: The LHS of an assignment operator can be *so* much more than just
+-- single variable.
+interpretStatement (Assign [Var identifier _] _ _) = bindIdent identifier
+interpretStatement (Assign {}) = terror "Unhandled assignment"
+interpretStatement (Fun name args _ body _) = do
+  bindIdent name
+  pushScope
+  mapM_ bindIdent $ concatMap paramName args
+  mapM_ interpretStatement body
+  void popScope
+  where
+    paramName (Param n _ _ _) = [n]
+    paramName (VarArgsPos n _ _) = [n]
+    paramName (VarArgsKeyword n _ _) = [n]
+    paramName (UnPackTuple tuple _ _) = tupleIdentifiers tuple
+    paramName _ = []
+
+    tupleIdentifiers (ParamTupleName n _) = [n]
+    tupleIdentifiers (ParamTuple ts _) = concatMap tupleIdentifiers ts
+interpretStatement (Return (Just expr) _) = interpretExpression expr
+interpretStatement (Return Nothing _) = return ()
+interpretStatement (StmtExpr expr _) = interpretExpression expr
+interpretStatement _ = return ()
+
+
+interpretExpression :: Expr a -> Scoped a ()
+interpretExpression (Var identifier _) = addReferenceIdent identifier
+interpretExpression (Call function args _) = do
+  interpretExpression function
+  mapM_ (interpretExpression . arg_expr) args
+interpretExpression (Subscript x y _) = do
+  interpretExpression x
+  interpretExpression y
+-- XXX: Should handle the slice args
+interpretExpression (SlicedExpr x _ _) = interpretExpression x
+interpretExpression (CondExpr trueBranch condition falseBranch _) = do
+  interpretExpression trueBranch
+  interpretExpression condition
+  interpretExpression falseBranch
+interpretExpression (BinaryOp _ left right _) = do
+  interpretExpression left
+  interpretExpression right
+interpretExpression (UnaryOp _ expr _) = interpretExpression expr
+-- XXX: Should handle attributes!
+interpretExpression (Dot expr _ _) = interpretExpression expr
+interpretExpression (Lambda _ body _) = do
+  pushScope
+  -- XXX: Handle parameter binding
+  interpretExpression body
+  void popScope
+interpretExpression (Tuple exprs _) = mapM_ interpretExpression exprs
+interpretExpression (Yield _ _) = terror "I can't be bothered implementing yield"
+-- XXX: should add a debug statement here
+interpretExpression _ = return ()

--- a/holborn-web/lib/Holborn/Scope.hs
+++ b/holborn-web/lib/Holborn/Scope.hs
@@ -1,0 +1,163 @@
+-- | Very simple model for lexical scopes.
+
+module Holborn.Scope ( Scoped
+                     , execScoped
+                     , pushScope
+                     , popScope
+                     , newScope
+                     , ID
+                     , Annotation(..)
+                     , addReference
+                     , bind
+                     , flattenScope
+                     ) where
+
+import BasicPrelude
+
+import Control.Monad.State (State, get, modify, state, runState)
+import qualified Data.Map as M
+
+
+-- | Annotation applied to a token. We are interested only in identifiers and
+-- how they are used: is an identifier being defined, or is it a reference?
+--
+-- For definitions, we store something that will help us find the definition
+-- again. For references, we store the location of the definition.
+data Annotation a = Binding a | Reference a deriving (Eq, Show)
+
+
+type Symbol = String
+type ID = Int
+
+-- Natural way to build the model is to have a stack of environments, and
+-- every time we come across a binding to insert that into the model, and also
+-- to note every time we come across a reference.
+--
+-- We want to then be able to do a second pass that just looks at the tokens
+-- and then consults this 'database' to see whether it is a definition or a
+-- reference or nothing
+--
+-- Therefore, the database needs to be indexed by something that we have when
+-- we have the tokens:
+--   probably source location
+--
+-- Therefore, when we insert the definitions or references, we need to make
+-- note of their source location
+--
+-- There will be some things which are ambiguous references, most notably,
+-- references to attributes on objects. We can think of those references as
+-- partial functions that can only be resolved when given other information.
+
+-- XXX: I don't have a way of handling redefinition within scope
+data Environment a = Env { definitions :: Map Symbol (ID, a)
+                         , references :: [(ID, a)]
+                         }
+
+newEnvironment :: Environment a
+newEnvironment = Env M.empty []
+
+
+flattenEnvironment :: Ord a => Environment a -> Map a (Annotation ID)
+flattenEnvironment env =
+  M.fromList $
+  [(srcSpan, Binding i) | (i, srcSpan) <- M.elems (definitions env)] ++
+  [(srcSpan, Reference i) | (i, srcSpan) <- references env]
+
+
+insertBinding :: Symbol -> ID -> a -> Environment a -> Environment a
+insertBinding symbol bindID srcSpan (Env env refs) = Env (M.insert symbol (bindID, srcSpan) env) refs
+
+insertReference :: Symbol -> ID -> a -> Environment a -> Environment a
+insertReference _ refID srcSpan (Env env refs) = Env env ((refID, srcSpan):refs)
+
+
+getBinding :: Symbol -> Environment a -> Maybe ID
+getBinding symbol environment = fst <$> M.lookup symbol (definitions environment)
+
+
+data Scope a = Scope { _stack :: [Environment a]
+                     , _root :: Environment a
+                     , _currentID :: ID
+                     , _past :: [Environment a]
+                     }
+
+
+-- XXX: I don't understand why I can't just make Scope implement Foldable. I
+-- think it's because that's for structures that don't know anything about
+-- their contents. Calling this foldMapScope to disambiguate, as some versions
+-- of basic-prelude export it.
+foldMapScope :: Monoid m => (Environment a -> m) -> Scope a -> m
+foldMapScope f scope =
+  case popEnvironment scope of
+    (Left env, _) -> f env
+    (Right env, scope') -> f env `mappend` foldMapScope f scope'
+
+
+newScope :: Scope a
+newScope = Scope [] newEnvironment 1 []
+
+flattenScope :: Ord a => Scope a -> Map a (Annotation ID)
+flattenScope scope = foldMapScope flattenEnvironment scope `mappend` mconcat (map flattenEnvironment (_past scope))
+
+findDefinition :: Symbol -> Scope a -> Maybe ID
+findDefinition symbol = listToMaybe . foldMapScope (maybeToList . getBinding symbol)
+
+pushEnvironment :: Environment a -> Scope a -> Scope a
+pushEnvironment env (Scope stack root x past) = Scope (env:stack) root x past
+
+popEnvironment :: Scope a -> (Either (Environment a) (Environment a), Scope a)
+popEnvironment scope@(Scope [] root _ _) = (Left root, scope)
+popEnvironment (Scope (env:rest) root x past) = (Right env, Scope rest root x (env:past))
+
+popEnvironment' :: Scope a -> (Environment a, Scope a)
+popEnvironment' scope =
+  let (env, scope') = popEnvironment scope in
+  case env of
+    Left env' -> (env', scope')
+    Right env' -> (env', scope')
+
+modifyEnvironment :: (Environment a -> Environment a) -> Scope a -> Scope a
+modifyEnvironment f (Scope [] root x past) = Scope [] (f root) x past
+modifyEnvironment f (Scope (env:rest) root x past) = Scope (f env:rest) root x past
+
+incrementID' :: Scope a -> (ID, Scope a)
+incrementID' (Scope stack root i past) = (i, Scope stack root (i + 1) past)
+
+
+type Scoped a = State (Scope a)
+
+
+runScoped :: Scoped location result -> Scope location -> (result, Scope location)
+runScoped = runState
+
+
+execScoped :: Scoped location result -> Scope location -> Scope location
+execScoped action = snd . runScoped action
+
+
+pushScope :: Scoped a ()
+pushScope = modify (pushEnvironment newEnvironment)
+
+
+popScope :: Scoped a (Environment a)
+popScope = state popEnvironment'
+
+
+incrementID :: Scoped a ID
+incrementID = state incrementID'
+
+
+bind :: Symbol -> a -> Scoped a ID
+bind symbol srcSpan = do
+  nextID <- incrementID
+  modify (modifyEnvironment (insertBinding symbol nextID srcSpan))
+  return nextID
+
+
+addReference :: Symbol -> a -> Scoped a ()
+addReference symbol srcSpan = do
+  definition <- findDefinition symbol <$> get
+  case definition of
+    Just i -> modify (modifyEnvironment (insertReference symbol i srcSpan))
+    -- XXX: Have something nicer for references that we can't resolve
+    _ -> return ()

--- a/holborn-web/lib/Holborn/Scope.hs
+++ b/holborn-web/lib/Holborn/Scope.hs
@@ -17,13 +17,7 @@ import BasicPrelude
 import Control.Monad.State (State, get, modify, state, runState)
 import qualified Data.Map as M
 
-
--- | Annotation applied to a token. We are interested only in identifiers and
--- how they are used: is an identifier being defined, or is it a reference?
---
--- For definitions, we store something that will help us find the definition
--- again. For references, we store the location of the definition.
-data Annotation a = Binding a | Reference a deriving (Eq, Show)
+import Holborn.Types (Annotation(..))
 
 
 type Symbol = String

--- a/holborn-web/lib/Holborn/Scope.hs
+++ b/holborn-web/lib/Holborn/Scope.hs
@@ -20,7 +20,7 @@ import qualified Data.Map as M
 import Holborn.Types (Annotation(..))
 
 
-type Symbol = String
+type Symbol = Text
 type ID = Int
 
 -- Natural way to build the model is to have a stack of environments, and

--- a/holborn-web/lib/Holborn/Types.hs
+++ b/holborn-web/lib/Holborn/Types.hs
@@ -1,10 +1,9 @@
 module Holborn.Types
-       ( Identifier(..)
-       , Annotation(..)
-       , Reference(..)
+       ( Annotation(..)
+       , Identifier(..)
        , HolbornToken(..)
+       , tokenAnnotation
        , tokenName
-       , tokenReference
        , tokenType
        ) where
 
@@ -12,27 +11,32 @@ import BasicPrelude
 import Text.Highlighter.Types (Token(..), TokenType)
 
 -- | A token with extra semantic information. More data to be added later.
-data HolbornToken = HolbornToken Token (Maybe Reference)
+data HolbornToken a = HolbornToken { _lexerToken :: Token
+                                   , _annotation :: Maybe (Annotation a)
+                                   }
 
--- | Opaque data type representing the location of a token in our yet-to-be-
--- defined semantic data structure.
-data Reference = Reference Text deriving Show
+
+-- | Annotation applied to a token. We are interested only in identifiers and
+-- how they are used: is an identifier being defined, or is it a reference?
+--
+-- For definitions, we store something that will help us find the definition
+-- again. For references, we store the location of the definition.
+data Annotation a = Binding a | Reference a deriving (Eq, Show)
+
 
 -- | An identifier found in code.
-data Identifier = Identifier ByteString Reference deriving Show
-
--- | Placeholder data structure for AST
--- XXX: This doesn't represent an AST any more. What *does* it represent?
-data Annotation = Annotation [Identifier]
+--
+-- Currently only used in example code.
+data Identifier a = Identifier ByteString a deriving Show
 
 
-tokenType :: HolbornToken -> TokenType
+tokenType :: HolbornToken a -> TokenType
 tokenType (HolbornToken (Token t _) _) = t
 
 
-tokenName :: HolbornToken -> ByteString
+tokenName :: HolbornToken a -> ByteString
 tokenName (HolbornToken (Token _ s) _) = s
 
 
-tokenReference :: HolbornToken -> Maybe Reference
-tokenReference (HolbornToken _ r) = r
+tokenAnnotation :: HolbornToken a -> Maybe (Annotation a)
+tokenAnnotation = _annotation

--- a/holborn-web/src/ExampleData.hs
+++ b/holborn-web/src/ExampleData.hs
@@ -6,10 +6,10 @@ module ExampleData (
 
 import BasicPrelude
 
-import Holborn.Types (Annotation(..), Reference(..), Identifier(..))
+import Holborn.Types (Identifier(..))
 
 examplePython :: Text
-examplePython = unlines (
+examplePython = unlines
   [ "# -*- coding: utf-8 -*-"
   , "#"
   , "# Copyright (c) 2015 Jonathan M. Lange <jml@mumak.net>"
@@ -32,22 +32,22 @@ examplePython = unlines (
   , "import itertools"
   , ""
   , ""
-  , "FORK = u'\\u251c'"
-  , "LAST = u'\\u2514'"
-  , "VERTICAL = u'\\u2502'"
-  , "HORIZONTAL = u'\\u2500'"
+  , "FORK = '\\u251c'"
+  , "LAST = '\\u2514'"
+  , "VERTICAL = '\\u2502'"
+  , "HORIZONTAL = '\\u2500'"
   , ""
   , ""
   , "def _format_tree(node, format_node, get_children, prefix=''):"
   , "    children = get_children(node)"
-  , "    next_prefix = u''.join([prefix, VERTICAL, u'   '])"
+  , "    next_prefix = ''.join([prefix, VERTICAL, '   '])"
   , "    for child in children[:-1]:"
-  , "        yield u''.join([prefix, FORK, HORIZONTAL, HORIZONTAL, u' ', format_node(child)])"
+  , "        yield ''.join([prefix, FORK, HORIZONTAL, HORIZONTAL, ' ', format_node(child)])"
   , "        for result in _format_tree(child, format_node, get_children, next_prefix):"
   , "            yield result"
   , "    if children:"
-  , "        last_prefix = u''.join([prefix, u'    '])"
-  , "        yield u''.join([prefix, LAST, HORIZONTAL, HORIZONTAL, u' ', format_node(children[-1])])"
+  , "        last_prefix = ''.join([prefix, '    '])"
+  , "        yield ''.join([prefix, LAST, HORIZONTAL, HORIZONTAL, ' ', format_node(children[-1])])"
   , "        for result in _format_tree(children[-1], format_node, get_children, last_prefix):"
   , "            yield result"
   , ""
@@ -56,20 +56,20 @@ examplePython = unlines (
   , "    lines = itertools.chain("
   , "        [format_node(node)],"
   , "        _format_tree(node, format_node, get_children),"
-  , "        [u''],"
+  , "        [''],"
   , "    )"
-  , "    return u'\\n'.join(lines)"
+  , "    return '\\n'.join(lines)"
   , ""
   , ""
   , "def print_tree(node, format_node, get_children):"
   , "    print format_tree(node, format_tree, get_children)"
-  ])
+  ]
 
 
-exampleAnnotation :: Annotation
+exampleAnnotation :: [Identifier Text]
 exampleAnnotation =
-  Annotation $ map decodeIdentifier exampleRaw
-  where decodeIdentifier [x, y] = Identifier x (Reference (decodeUtf8 y))
+  map decodeIdentifier exampleRaw
+  where decodeIdentifier [x, y] = Identifier x (decodeUtf8 y)
 
 
 exampleRaw :: [[ByteString]]

--- a/holborn-web/src/Main.hs
+++ b/holborn-web/src/Main.hs
@@ -8,7 +8,7 @@ import Text.Blaze.Html.Renderer.Utf8 (renderHtml)
 import Text.Blaze.Html (Html)
 
 
-import ExampleData (examplePython, exampleAnnotation)
+import ExampleData (examplePython)
 
 -- XXX: Is there a better way of sending blaze to the user with Spock?
 blaze :: MonadIO m => Html -> ActionT m a
@@ -17,4 +17,4 @@ blaze = lazyBytes . renderHtml
 main :: IO ()
 main =
     runSpock 8080 $ spockT id $
-    get root $ blaze $ codePage $ renderPythonCode examplePython exampleAnnotation
+    get root $ blaze $ codePage $ renderPythonCode examplePython

--- a/holborn-web/tests/PythonBindings.hs
+++ b/holborn-web/tests/PythonBindings.hs
@@ -1,0 +1,48 @@
+module PythonBindings where
+
+import BasicPrelude
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+
+import Holborn.Python (annotateSourceCode)
+import Holborn.Scope (Annotation(..), ID)
+
+
+pythonInput :: Text
+pythonInput =
+  unlines [ "x = 2"
+          , "def f(y):"
+          , "  return x + y"
+          , "f(3)"
+          ]
+
+
+expectedOutput :: [(String, Maybe (Annotation ID))]
+expectedOutput =
+  [ ("x", Just (Binding 1))
+  , ("=", Nothing)
+  , ("2", Nothing)
+  , ("def", Nothing)
+  , ("f", Just (Binding 2))
+  , ("(", Nothing)
+  , ("y", Just (Binding 3))
+  , (")", Nothing)
+  , (":", Nothing)
+  , ("return", Nothing)
+  , ("x", Just (Reference 1))
+  , ("+", Nothing) -- maybe actually a reference?
+  , ("y", Just (Reference 3))
+  , ("f", Just (Reference 2))
+  , ("(", Nothing)
+  , ("3", Nothing)
+  , (")", Nothing)
+  ]
+
+
+tests :: TestTree
+tests =
+  testGroup "scope tests"
+  [ testCase "very simple example" $
+    Right expectedOutput @=? annotateSourceCode pythonInput
+  ]

--- a/holborn-web/tests/Tests.hs
+++ b/holborn-web/tests/Tests.hs
@@ -6,6 +6,8 @@ import Test.Tasty.QuickCheck
 
 import Holborn.Web (leftMergeBy)
 
+import qualified PythonBindings
+
 
 allLeftsInResult :: Eq a => (a -> b -> Bool) -> [a] -> [b] -> Bool
 allLeftsInResult f xs ys =
@@ -28,18 +30,21 @@ onlyRights ys = not (null ys) ==> leftMergeBy (==) [] ys == Left ys
 
 tests :: TestTree
 tests =
-  testGroup "Web tests"
-  [ testGroup "leftMerge"
-    [ testProperty "allLeftsInResult" $ \(xs, ys) -> allLeftsInResult (==) xs (ys :: [Int])
-    , testProperty "identicalLists" $ \xs -> identicalLists (xs :: [Int])
-    , testProperty "onlyLefts" $ \xs -> onlyLefts (xs :: [Int])
-    , testProperty "onlyRights" $ \xs -> onlyRights (xs :: [Int])
+  testGroup "Holborn tests"
+  [ testGroup "Web tests"
+    [ testGroup "leftMerge"
+      [ testProperty "allLeftsInResult" $ \(xs, ys) -> allLeftsInResult (==) xs (ys :: [Int])
+      , testProperty "identicalLists" $ \xs -> identicalLists (xs :: [Int])
+      , testProperty "onlyLefts" $ \xs -> onlyLefts (xs :: [Int])
+      , testProperty "onlyRights" $ \xs -> onlyRights (xs :: [Int])
+      ]
+    , testGroup "leftMerge unit tests"
+      [ testCase "worked example" $
+        leftMergeBy (==) ([1, 2, 3, 4, 5] :: [Int]) [1, 3, 5]
+        @?= Right [(1, Just 1), (2, Nothing), (3, Just 3), (4, Nothing), (5, Just 5)]
+      ]
     ]
-  , testGroup "leftMerge unit tests"
-    [ testCase "worked example" $
-      leftMergeBy (==) ([1, 2, 3, 4, 5] :: [Int]) [1, 3, 5]
-      @?= Right [(1, Just 1), (2, Nothing), (3, Just 3), (4, Nothing), (5, Just 5)]
-    ]
+  , PythonBindings.tests
   ]
 
 


### PR DESCRIPTION
Now ready to be reviewed. (Check out my mad rebase skills).

Adds a [language-python](https://hackage.haskell.org/package/language-python) dependency and uses Haskell to analyze the Python AST, figure out where the bindings are and which bindings any[1] given reference refers to. Updates the trivial web view to use this.

Means a bunch of changes to the core types. You were right, defining them while we were in Bilbao was premature. Defining them now is also premature, but I hope they're a little simpler. 

Note in particular that I've made "reference" abstract. It's now just a type variable.

[1] By which I mean, "some kinds of"

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jml/holborn/12)
<!-- Reviewable:end -->
