### PR TITLE
Bump to basic-prelude 0.5 and Spock 0.8

### DIFF
--- a/holborn-web/holborn-web.cabal
+++ b/holborn-web/holborn-web.cabal
@@ -18,8 +18,7 @@ library
                      , Holborn.HtmlFormat
                      , Holborn.Types
   build-depends:       base >=4.8 && <4.9
-                       -- We want basic-prelude 0.4.0, but it's not in Nix yet.
-                     , basic-prelude >= 0.3.13 && <0.6
+                     , basic-prelude >= 0.5 && <0.6
                      , highlighter2 >= 0.2 && <0.3
                      , blaze-html >= 0.8 && <0.9
                      , text >= 1.2 && <1.3
@@ -36,7 +35,7 @@ executable holborn
   default-language:    Haskell2010
   other-modules:       ExampleData
   build-depends:       base >=4.8 && <4.9
-                     , Spock >= 0.7.9 && <0.8
+                     , Spock >= 0.8 && <0.9
                      , basic-prelude >= 0.3.13 && <0.6
                      , blaze-html >= 0.8 && <0.9
                      , holborn-web

--- a/holborn-web/shell.nix
+++ b/holborn-web/shell.nix
@@ -1,2 +1,2 @@
 with (import <nixpkgs> {}).pkgs;
-(haskellngPackages.callPackage ./. {}).env
+(haskellPackages.callPackage ./. {}).env


### PR DESCRIPTION
I've pulled the latest nixpkgs and I think it's safe for us to rely on these.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jml/holborn/14)
<!-- Reviewable:end -->
