### PR TITLE
Switch to Protolude

### DIFF
--- a/hcl/hcl.cabal
+++ b/hcl/hcl.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -13,7 +13,7 @@ executable hcl-unused
   build-depends:
       base >=4.9 && <5
     , holborn-prelude
-    , turtle >=1.2
+    , turtle
   hs-source-dirs:
       src
   ghc-options: -Wall -Werror -threaded
@@ -25,7 +25,6 @@ executable hcl-wait-for-port
   build-depends:
       base >=4.9 && <5
     , holborn-prelude
-    , turtle >=1.2
     , optparse-applicative
     , network-simple >= 0.4
   hs-source-dirs:

--- a/hcl/package.yaml
+++ b/hcl/package.yaml
@@ -14,7 +14,6 @@ source-dirs: src
 dependencies:
   - base >=4.9 && <5
   - holborn-prelude
-  - turtle >=1.2
 
 executables:
   hcl-wait-for-port:
@@ -25,3 +24,5 @@ executables:
 
   hcl-unused:
     main: unused.hs
+    dependencies:
+      - turtle

--- a/hcl/src/wait-for-port.hs
+++ b/hcl/src/wait-for-port.hs
@@ -3,7 +3,6 @@ module Main (main) where
 
 import HolbornPrelude
 
-import Turtle hiding (hostname, option, options, stderr, switch)
 import Control.Concurrent (threadDelay)
 import Network.Simple.TCP (connectSock)
 import Options.Applicative
@@ -62,7 +61,7 @@ waitForPort host port timeout delay verbose
       pure (ExitFailure 1)
   | otherwise = do
       when verbose $ putStr $ "Connecting to " <> serverAddr host port <> " ... "
-      result <- try (connectSock host ((textToString . show) port))
+      result <- try (connectSock host (show port))
       case result of
         Left (_ :: IOException) -> do
           when verbose $ putStr "Failed\n"

--- a/holborn-api/holborn-api-server/Main.hs
+++ b/holborn-api/holborn-api-server/Main.hs
@@ -80,7 +80,7 @@ warpSettings :: Warp.Port -> Warp.Settings
 warpSettings port =
   Warp.setBeforeMainLoop printPort (Warp.setPort port' Warp.defaultSettings)
   where
-    printPort = Log.info $ "holborn-api running at http://localhost:" ++ show port' ++ "/"
+    printPort = Log.info $ "holborn-api running at http://localhost:" ++ (show port' :: Text) ++ "/"
     port' = port
 
 

--- a/holborn-api/lib/Holborn/API/Internal.hs
+++ b/holborn-api/lib/Holborn/API/Internal.hs
@@ -37,8 +37,6 @@ import HolbornPrelude
 import Control.Error (bimapExceptT)
 import Control.Monad.Catch (MonadThrow(..))
 import Control.Monad.Fail (MonadFail(..))
-import Control.Monad.Trans.Except (ExceptT, throwE)
-import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 import Data.Aeson (FromJSON, ToJSON, Value, eitherDecode', encode, object, (.=))
 import qualified Database.PostgreSQL.Simple as PostgreSQL
 import Database.PostgreSQL.Simple.Internal (RowParser)
@@ -123,7 +121,7 @@ instance (JSONCodeableError a) => JSONCodeableError (APIError a) where
     toJSON NoUserAccount = (418, object [])
     toJSON InsufficientPermissions = (403, object [])
     toJSON (SubAPIError x) = toJSON x
-    toJSON (UnexpectedException e) = (500, object [ "message" .= show e
+    toJSON (UnexpectedException e) = (500, object [ "message" .= (show e :: Text)
                                                   , "type" .= ("UncaughtException" :: Text)
                                                   ])
     toJSON (BrokenCode msg) = (500, object [ "message" .= msg
@@ -138,7 +136,7 @@ throwHandlerError = throwAPIError . SubAPIError
 
 -- | Raise a general API error.
 throwAPIError :: APIError err -> APIHandler err a
-throwAPIError = APIHandler . lift . throwE
+throwAPIError = APIHandler . lift . throwError
 
 
 -- | The internal "configuration" of the application. Collects things used

--- a/holborn-api/lib/Holborn/API/NewRepo.hs
+++ b/holborn-api/lib/Holborn/API/NewRepo.hs
@@ -12,6 +12,7 @@ module Holborn.API.NewRepo
 
 import HolbornPrelude
 
+import Control.Monad (fail)
 import Data.Aeson (FromJSON(..), Value(String), object, (.=))
 import Data.Aeson.Types (typeMismatch)
 import Servant

--- a/holborn-api/tests/Helpers.hs
+++ b/holborn-api/tests/Helpers.hs
@@ -14,7 +14,7 @@ module Helpers
   , postAs
   ) where
 
-import HolbornPrelude
+import HolbornPrelude hiding (get)
 
 import Control.Monad.Trans.Except (runExceptT)
 import Data.Aeson (FromJSON, ToJSON, decode, encode)

--- a/holborn-api/tests/Internal.hs
+++ b/holborn-api/tests/Internal.hs
@@ -38,6 +38,6 @@ jsonGetTests getDB =
       let expectedException = UnexpectedException (toException (InvalidUrlException badUrl "Invalid URL")) :: APIError Int
       result <- runExceptT (runAPIHandler config apiResult)
       case result of
-        Left e -> show expectedException @?= show e
+        Left e -> show expectedException @?= (show e :: Text)
         Right _ -> assertFailure $ "Unexpectedly parsed URL: " ++ badUrl
   ]

--- a/holborn-api/tests/Postgres.hs
+++ b/holborn-api/tests/Postgres.hs
@@ -16,6 +16,7 @@ import HolbornPrelude
 import Data.Word (Word16)
 import Database.PostgreSQL.Simple (ConnectInfo(..), defaultConnectInfo)
 import System.Exit (ExitCode(..))
+import System.IO.Error (userError)
 import qualified System.Process as P
 import System.Posix.Temp (mkdtemp)
 

--- a/holborn-api/tests/Settings/SSHKeys.hs
+++ b/holborn-api/tests/Settings/SSHKeys.hs
@@ -2,7 +2,7 @@
 
 module Settings.SSHKeys (spec) where
 
-import HolbornPrelude
+import HolbornPrelude hiding (get)
 
 import Data.Aeson (FromJSON, Object, object, (.=), (.:))
 import Data.Aeson.Types (parseMaybe)

--- a/holborn-api/tests/Types.hs
+++ b/holborn-api/tests/Types.hs
@@ -14,5 +14,5 @@ tests =
   testGroup "Holborn.API.Types"
   [ testCase "password not shown" $ do
         pwd <- newPassword "hello"
-        show pwd @?= "*hidden-password*"
+        (show pwd :: Text) @?= "*hidden-password*"
   ]

--- a/holborn-common-types/holborn-common-types.cabal
+++ b/holborn-common-types/holborn-common-types.cabal
@@ -34,7 +34,7 @@ library
     , time
   hs-source-dirs:
       lib
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall
   default-language: Haskell2010
   default-extensions: GeneralizedNewtypeDeriving NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards
 
@@ -42,7 +42,7 @@ test-suite holborn-common-types-test
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   default-extensions: GeneralizedNewtypeDeriving NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards
-  ghc-options: -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -O2 -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:
       tests
   main-is: Main.hs

--- a/holborn-common-types/package.yaml
+++ b/holborn-common-types/package.yaml
@@ -3,7 +3,8 @@ version: 0.1.3.0
 synopsis: Types shared between our nodes
 license: AllRightsReserved
 
-ghc-options: -Wall -Werror
+# Disable -Werror while we port to protolude
+ghc-options: -Wall
 default-extensions:
   - GeneralizedNewtypeDeriving
   - NamedFieldPuns

--- a/holborn-prelude/default.nix
+++ b/holborn-prelude/default.nix
@@ -1,13 +1,13 @@
-{ mkDerivation, base, basic-prelude, mtl, safe, stdenv, tasty
+{ mkDerivation, base, mtl, protolude, safe, stdenv, tasty
 , tasty-hspec, tasty-hunit, tasty-quickcheck, text
 }:
 mkDerivation {
   pname = "holborn-prelude";
   version = "0.1.0.0";
   src = ./.;
-  libraryHaskellDepends = [ base basic-prelude mtl safe text ];
+  libraryHaskellDepends = [ base mtl protolude safe text ];
   testHaskellDepends = [
-    base basic-prelude mtl safe tasty tasty-hspec tasty-hunit
+    base mtl protolude safe tasty tasty-hspec tasty-hunit
     tasty-quickcheck text
   ];
   description = "Standard prelude for Holborn";

--- a/holborn-prelude/holborn-prelude.cabal
+++ b/holborn-prelude/holborn-prelude.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -16,6 +16,7 @@ library
   ghc-options: -Wall -Werror
   build-depends:
       base >=4.9 && <5
+    , hashable
     , mtl
     , protolude >= 0.1.6
     , safe >= 0.3.9
@@ -35,6 +36,7 @@ test-suite holborn-prelude-tests
   ghc-options: -Wall -Werror -eventlog
   build-depends:
       base >=4.9 && <5
+    , hashable
     , mtl
     , protolude >= 0.1.6
     , safe >= 0.3.9

--- a/holborn-prelude/holborn-prelude.cabal
+++ b/holborn-prelude/holborn-prelude.cabal
@@ -16,8 +16,8 @@ library
   ghc-options: -Wall -Werror
   build-depends:
       base >=4.9 && <5
-    , basic-prelude >= 0.5.2
     , mtl
+    , protolude >= 0.1.6
     , safe >= 0.3.9
     , text >= 1.2.2
   exposed-modules:
@@ -35,8 +35,8 @@ test-suite holborn-prelude-tests
   ghc-options: -Wall -Werror -eventlog
   build-depends:
       base >=4.9 && <5
-    , basic-prelude >= 0.5.2
     , mtl
+    , protolude >= 0.1.6
     , safe >= 0.3.9
     , text >= 1.2.2
     , holborn-prelude

--- a/holborn-prelude/package.yaml
+++ b/holborn-prelude/package.yaml
@@ -15,8 +15,8 @@ default-extensions:
 
 dependencies:
   - base >=4.9 && <5
-  - basic-prelude >= 0.5.2
   - mtl
+  - protolude >= 0.1.6
   - safe >= 0.3.9
   - text >= 1.2.2
 

--- a/holborn-prelude/package.yaml
+++ b/holborn-prelude/package.yaml
@@ -15,6 +15,7 @@ default-extensions:
 
 dependencies:
   - base >=4.9 && <5
+  - hashable
   - mtl
   - protolude >= 0.1.6
   - safe >= 0.3.9

--- a/holborn-proxy/holborn-proxy.cabal
+++ b/holborn-proxy/holborn-proxy.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -42,7 +42,7 @@ library
       lib
   default-language: Haskell2010
   default-extensions: GeneralizedNewtypeDeriving MonadFailDesugaring NamedFieldPuns NoImplicitPrelude OverloadedStrings ScopedTypeVariables RecordWildCards
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall
 
 executable holborn-proxy
   build-depends:
@@ -58,7 +58,7 @@ executable holborn-proxy
     , warp-tls >=3.2.1
   hs-source-dirs:
       src
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall
   main-is: holborn-proxy.hs
   default-language: Haskell2010
   default-extensions: GeneralizedNewtypeDeriving MonadFailDesugaring NamedFieldPuns NoImplicitPrelude OverloadedStrings ScopedTypeVariables RecordWildCards

--- a/holborn-proxy/lib/Holborn/Proxy/AuthJar.hs
+++ b/holborn-proxy/lib/Holborn/Proxy/AuthJar.hs
@@ -11,7 +11,7 @@ module Holborn.Proxy.AuthJar
   ) where
 
 
-import HolbornPrelude
+import HolbornPrelude hiding (get)
 
 import qualified Data.HashMap.Strict as HashMap
 import Control.Concurrent.STM.TVar (newTVarIO, modifyTVar', readTVar, TVar)

--- a/holborn-proxy/lib/Holborn/Proxy/HttpTermination.hs
+++ b/holborn-proxy/lib/Holborn/Proxy/HttpTermination.hs
@@ -8,12 +8,13 @@ module Holborn.Proxy.HttpTermination
   , proxyApp
   ) where
 
-import HolbornPrelude
+import HolbornPrelude hiding (get)
 
 import Control.Error (hoistMaybe)
 import Control.Monad.Trans.Maybe (runMaybeT)
 import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Lazy as BSL
+import Data.List (lookup)
 import Network.HTTP.Client (Manager)
 import Network.HTTP.ReverseProxy (defaultOnExc, waiProxyTo, WaiProxyResponse(..), ProxyDest(..))
 import Network.HTTP.Types (status302, status200, Header)

--- a/holborn-proxy/package.yaml
+++ b/holborn-proxy/package.yaml
@@ -3,6 +3,7 @@ version: 0.1.0.0
 synopsis: Reverse proxy / http terminator for holborn
 license: AllRightsReserved
 
+# Temporarily disable -Werror while migrating to Protolude
 ghc-options: -Wall
 default-extensions:
   - GeneralizedNewtypeDeriving
@@ -19,7 +20,6 @@ dependencies:
 
 library:
   source-dirs: lib
-  ghc-options: -Werror
   dependencies:
     - aeson
     - base64-bytestring
@@ -47,7 +47,6 @@ executables:
   holborn-proxy:
     main: holborn-proxy.hs
     source-dirs: src
-    ghc-options: -Werror
     dependencies:
       - holborn-proxy
       - http-client

--- a/holborn-repo/holborn-repo.cabal
+++ b/holborn-repo/holborn-repo.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -26,7 +26,7 @@ library
       lib
   default-language: Haskell2010
   default-extensions: GeneralizedNewtypeDeriving MonadFailDesugaring NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards ScopedTypeVariables RecordWildCards
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall
   build-depends:
       base >=4.9 && <5
     , holborn-prelude
@@ -73,7 +73,7 @@ executable holborn-repo
   hs-source-dirs:
       src
   default-language: Haskell2010
-  ghc-options: -Wall -Werror -threaded -rtsopts
+  ghc-options: -Wall -threaded -rtsopts
   default-extensions: GeneralizedNewtypeDeriving MonadFailDesugaring NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards ScopedTypeVariables RecordWildCards
   build-depends:
       base >=4.9 && <5
@@ -92,7 +92,7 @@ test-suite holborn-repo-tests
   hs-source-dirs:
       tests
   default-extensions: GeneralizedNewtypeDeriving MonadFailDesugaring NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards ScopedTypeVariables RecordWildCards
-  ghc-options: -Wall -Werror -eventlog
+  ghc-options: -Wall -eventlog
   build-depends:
       base >=4.9 && <5
     , holborn-prelude

--- a/holborn-repo/lib/Holborn/Repo/Config.hs
+++ b/holborn-repo/lib/Holborn/Repo/Config.hs
@@ -26,5 +26,5 @@ warpSettings :: Config -> Settings
 warpSettings config =
   setBeforeMainLoop printPort (setPort port' defaultSettings)
   where
-    printPort = Log.info $ "holborn-repo running at http://localhost:" ++ show port' ++ "/"
+    printPort = Log.info ("holborn-repo running at http://localhost:" ++ show port' ++ "/" :: Text)
     port' = port config

--- a/holborn-repo/lib/Holborn/Repo/GitLayer.hs
+++ b/holborn-repo/lib/Holborn/Repo/GitLayer.hs
@@ -168,7 +168,7 @@ instance ToMarkup Blob where
         -- parse error so we can debug better.
         H.div $ do
           void "Could not parse"
-          H.pre $ toMarkup (show e)
+          H.pre $ toMarkup (show e :: Text)
         H.pre $ toMarkup (decodeUtf8 contents)
       Right annotated -> toMarkup annotated
     where

--- a/holborn-repo/lib/Holborn/Repo/HtmlFormatTokens.hs
+++ b/holborn-repo/lib/Holborn/Repo/HtmlFormatTokens.hs
@@ -6,7 +6,7 @@
 
 module Holborn.Repo.HtmlFormatTokens () where
 
-import HolbornPrelude hiding (div, span)
+import HolbornPrelude hiding (div)
 
 import Text.Blaze (ToMarkup(..))
 import Text.Blaze.Html5 (Html, (!))
@@ -57,7 +57,7 @@ instance (H.ToValue a, Show a) => ToMarkup (HolbornToken a) where
      baseToken = H.span ! A.class_ (tokenShortName token) $ H.toHtml contents
      contents = decodeUtf8 (tokenName token)
      findReferencesUrl = "https://google.com/?q=" ++ decodeUtf8 (tokenName token)
-     bindingUrl i = "#" ++ show i
+     bindingUrl i = "#" ++ show i :: Text
 
 
 instance ToMarkup HolbornSource where
@@ -76,9 +76,9 @@ lineNos n = lineNos' 1
   where
     lineNos' c
         | c <= n = do
-            H.a ! A.href (H.toValue $ "#L-" ++ show c)
-                ! A.name (H.toValue $ "L-" ++ show c) $
-              H.toHtml (show c)
+            H.a ! A.href (H.toValue ("#L-" ++ show c :: Text))
+                ! A.name (H.toValue ("L-" ++ show c :: Text)) $
+              H.toHtml (show c :: Text)
 
             H.toHtml ("\n" :: Text)
 

--- a/holborn-repo/lib/Holborn/Repo/HttpProtocol.hs
+++ b/holborn-repo/lib/Holborn/Repo/HttpProtocol.hs
@@ -19,6 +19,7 @@ import           HolbornPrelude
 
 import           Blaze.ByteString.Builder (Builder, fromByteString)
 import qualified Data.ByteString as BS
+import           Data.List (lookup)
 import           Network.HTTP.Types.Header (hContentEncoding, RequestHeaders)
 import           Network.HTTP.Types.Status (ok200)
 import           Network.Wai (Application, responseStream, requestBody, requestHeaders, Request, Response)

--- a/holborn-repo/lib/Holborn/Repo/Process.hs
+++ b/holborn-repo/lib/Holborn/Repo/Process.hs
@@ -3,7 +3,7 @@ module Holborn.Repo.Process
        , Process.proc
        ) where
 
-import           HolbornPrelude
+import           HolbornPrelude hiding (stdin, stdout)
 
 import           Control.Concurrent (forkIO)
 import           Control.Concurrent.MVar (newMVar, modifyMVar_)

--- a/holborn-repo/lib/Holborn/Repo/RawProtocol.hs
+++ b/holborn-repo/lib/Holborn/Repo/RawProtocol.hs
@@ -14,7 +14,6 @@ module Holborn.Repo.RawProtocol
 
 import           HolbornPrelude
 
-import           Control.Monad.State.Strict (runStateT)
 import           Network.Socket (Socket, SockAddr)
 import           Pipes.Core (Consumer, Producer)
 import           Pipes.Network.TCP (HostPreference(..))
@@ -66,7 +65,7 @@ accept :: Config -> (Socket, SockAddr) -> IO ()
 accept config (sock, _) = do
     let from = fromSocket sock 4096
     let to = toSocket sock
-    (header, fromRest) <- runStateT getRepoParser from
+    (header, fromRest) <- PP.runStateT getRepoParser from
     Log.debug header
     void $ case header of
         Just (WritableRepoCall GitUploadPack repoId) ->

--- a/holborn-repo/package.yaml
+++ b/holborn-repo/package.yaml
@@ -3,7 +3,8 @@ version: 0.1.0.0
 synopsis: Serve git repositories
 license: AllRightsReserved
 
-ghc-options: -Wall -Werror
+# Temporarily disabling -Werror for protolude migration.
+ghc-options: -Wall
 default-extensions:
   - GeneralizedNewtypeDeriving
   - MonadFailDesugaring

--- a/holborn-syntax/default.nix
+++ b/holborn-syntax/default.nix
@@ -11,7 +11,7 @@ mkDerivation {
     language-python mtl pretty-error text
   ];
   testHaskellDepends = [
-    base holborn-prelude tasty tasty-hunit tasty-quickcheck
+    base holborn-prelude tasty tasty-hunit tasty-quickcheck text
   ];
   description = "Syntax analysis library";
   license = stdenv.lib.licenses.unfree;

--- a/holborn-syntax/holborn-syntax.cabal
+++ b/holborn-syntax/holborn-syntax.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -19,6 +19,7 @@ library
   build-depends:
       base >= 4.9 && < 5.0
     , holborn-prelude
+    , text
     , bytestring >= 0.10
     , containers >= 0.5
     , errors >= 2.0
@@ -26,12 +27,11 @@ library
     , language-python >= 0.5.2
     , mtl >= 2.2
     , pretty-error
-    , text >= 1.2
   hs-source-dirs:
       lib
   default-language: Haskell2010
   default-extensions: GeneralizedNewtypeDeriving MonadFailDesugaring NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall
 
 test-suite holborn-syntax-test
   type: exitcode-stdio-1.0
@@ -39,10 +39,11 @@ test-suite holborn-syntax-test
   hs-source-dirs:
       tests
   default-extensions: GeneralizedNewtypeDeriving MonadFailDesugaring NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall
   build-depends:
       base >= 4.9 && < 5.0
     , holborn-prelude
+    , text
     , holborn-syntax
     , tasty
     , tasty-hunit

--- a/holborn-syntax/lib/Holborn/Syntax/Languages/Python.hs
+++ b/holborn-syntax/lib/Holborn/Syntax/Languages/Python.hs
@@ -21,11 +21,10 @@ Currently missing support for:
 -}
 module Holborn.Syntax.Languages.Python (annotateSourceCode, getAST, ParseError, Token) where
 
-import HolbornPrelude hiding (lex)
+import HolbornPrelude hiding (Handler)
 
 import qualified Data.Map as M
 import Data.Text (pack)
-import Debug.Trace
 import Language.Python.Common ( Argument(..)
                               , Comprehension(..)
                               , ComprehensionExpr(..)

--- a/holborn-syntax/package.yaml
+++ b/holborn-syntax/package.yaml
@@ -3,7 +3,8 @@ version: 0.3.0.0
 synopsis: Syntax analysis library
 license: AllRightsReserved
 
-ghc-options: -Wall -Werror
+# Temporarily disable -Werror while we migrate to Protolude
+ghc-options: -Wall
 default-extensions:
   - GeneralizedNewtypeDeriving
   - MonadFailDesugaring
@@ -15,6 +16,7 @@ default-extensions:
 dependencies:
   - base >= 4.9 && < 5.0
   - holborn-prelude
+  - text
 
 library:
   source-dirs: lib
@@ -26,7 +28,6 @@ library:
     - language-python >= 0.5.2
     - mtl >= 2.2
     - pretty-error
-    - text >= 1.2
 
 tests:
   holborn-syntax-test:

--- a/holborn-syntax/tests/PythonBindings.hs
+++ b/holborn-syntax/tests/PythonBindings.hs
@@ -6,6 +6,7 @@ module PythonBindings (tests) where
 import HolbornPrelude
 import Control.Applicative (Alternative)
 
+import Data.Text (words, unlines)
 import Test.Tasty (TestTree, TestName, testGroup)
 import Test.Tasty.HUnit
 


### PR DESCRIPTION
Lots of goodness here:
- extra debugging info
- generic text functions everywhere
- fewer partial functions

http://www.stephendiehl.com/posts/protolude.html for more details.

My preference was to avoid changing non-prelude code, but I ended up doing so in three general categories:
- adding a type constraint to `show`, which is now generic
- hiding or altering imports
- small, one-off things in code that's not changing much recently

Hopefully this won't cause too many conflicts with your work.

I'd like to get this merged soon, and then do follow-up PRs that fix each of the deprecation warnings one at a time.
