### PR TITLE
Replace 'terror' with 'error'

### DIFF
--- a/holborn-api/tests/Helpers.hs
+++ b/holborn-api/tests/Helpers.hs
@@ -55,7 +55,7 @@ mutateDB :: (ToRow args, Show args, MonadIO m) => Config -> Query -> args -> m I
 mutateDB config query params = do
   result <- liftIO $ runExceptT $ runAPIHandler config $ execute query params
   case result of
-    Left _ -> terror $ "Error running query: " <> show query <> " " <> show params
+    Left _ -> error $ "Error running query: " <> show query <> " " <> show params
     Right r -> pure r
 
 -- | Make an arbitrary user for testing.

--- a/holborn-common-types/lib/Holborn/CommonTypes/Repo.hs
+++ b/holborn-common-types/lib/Holborn/CommonTypes/Repo.hs
@@ -72,8 +72,8 @@ instance FromField (Name a) where
     -- TODO: Remove these partial functions.
     fromField _ (Just bs) = case newName (decodeUtf8 bs) of
         Just x -> pure x
-        Nothing -> terror ("Could not parse repo name. " <> decodeUtf8 bs)
-    fromField _ Nothing = terror "FromField Permissions should always decode correctly"
+        Nothing -> error ("Could not parse repo name. " <> decodeUtf8 bs)
+    fromField _ Nothing = error "FromField Permissions should always decode correctly"
 
 
 instance ToField (Name a) where

--- a/holborn-common-types/lib/Holborn/JSON/SSHRepoCommunication.hs
+++ b/holborn-common-types/lib/Holborn/JSON/SSHRepoCommunication.hs
@@ -222,7 +222,7 @@ instance FromField SSHKey where
         _ -> returnError ConversionFailed f ("Invalid SSH key in database: " <> textToString (show bs))
 
     -- TODO: Move corruptDatabase to holborn-prelude and use that
-    fromField _ _ = terror "FromField SSHKey should always decode correctly"
+    fromField _ _ = error "FromField SSHKey should always decode correctly"
 
 instance ToField SSHKey where
     toField = Escape . unparseSSHKey
@@ -242,7 +242,7 @@ sshFingerprint keyData = do
     pure path
   (exitCode, out, err) <- readProcessWithExitCode "ssh-keygen" ["-l", "-f", keyPath] ""
   case exitCode of
-    ExitFailure 127 -> terror "Could not find ssh-keygen process"
+    ExitFailure 127 -> error "Could not find ssh-keygen process"
     ExitFailure errCode -> do
       putStrLn $ "ssh-keygen failed: (" <> show errCode <>  ")"
       putStrLn $ "output:\n" <> fromString out

--- a/holborn-prelude/lib/HolbornPrelude.hs
+++ b/holborn-prelude/lib/HolbornPrelude.hs
@@ -59,7 +59,6 @@ import GHC.Exts (IsString(..))
 import System.IO (hPutStrLn)
 
 import Protolude hiding ((<>), (++), concat, intercalate, putStr, putStrLn, fromStrict, yield)
-import qualified Base
 import qualified Show
 
 (++) :: Monoid m => m -> m -> m

--- a/holborn-prelude/lib/HolbornPrelude.hs
+++ b/holborn-prelude/lib/HolbornPrelude.hs
@@ -12,7 +12,6 @@ module HolbornPrelude
     --
     -- To make migrating to Protolude easier.
   , id
-  , terror
     -- | Protolude doesn't export much String stuff, this is mostly a good
     -- thing, but we're going to export some String stuff to make our lives
     -- easier.
@@ -94,10 +93,6 @@ printErr = hPutStrLn stderr . toS
 --   > intercalate = mconcat .: intersperse
 intercalate :: Monoid w => w -> [w] -> w
 intercalate xs xss = mconcat (Data.List.intersperse xs xss)
-
-{-# DEPRECATED terror "Use 'error' instead" #-}
-terror :: Text -> a
-terror = Base.error . toS
 
 {-# DEPRECATED textToString "Use 'toS' instead" #-}
 textToString :: Text -> String

--- a/holborn-repo/lib/Holborn/Repo/HttpProtocol.hs
+++ b/holborn-repo/lib/Holborn/Repo/HttpProtocol.hs
@@ -74,7 +74,7 @@ smartHandshake diskLocation service =
             (gitPack' serviceType)
 
     backupResponse :: Response
-    backupResponse = terror "no git service specified: I have no idea whether we can reach this state."
+    backupResponse = error "no git service specified: I have no idea whether we can reach this state."
 
     gitPack' :: GitCommand -> (Builder -> IO ()) -> IO () -> IO ()
     gitPack' serviceType moreData _flush =
@@ -169,7 +169,7 @@ filterStdErr = do
     x <- await
     case x of
          -- TODO send errors to journald && maybe measure
-         Left err -> terror (decodeUtf8 err)
+         Left err -> error (decodeUtf8 err)
          Right data' -> do
              yield data'
              filterStdErr

--- a/holborn-repo/lib/Holborn/Repo/RawProtocol.hs
+++ b/holborn-repo/lib/Holborn/Repo/RawProtocol.hs
@@ -74,7 +74,7 @@ accept config (sock, _) = do
             gitReceivePack (getLocation' repoId) fromRest to
             -- TODO: This doesn't appear to abort the connection, which is
             -- what we want it to do.
-        _ -> terror $ "Bad header: " <> show header
+        _ -> error $ "Bad header: " <> show header
     return ()
   where
     getLocation' = getLocation config

--- a/holborn-ssh/holborn-authorized-keys/Main.hs
+++ b/holborn-ssh/holborn-authorized-keys/Main.hs
@@ -110,8 +110,7 @@ url = eitherReader parseUrl
     parseUrl s = fmapL (textToString . show) (parseBaseUrl s)
 
 defaultApiUrl :: BaseUrl
-defaultApiUrl = fromMaybe (terror "Default URL is broken") (parseBaseUrl "http://localhost:8002")
-
+defaultApiUrl = fromMaybe (panic "Default URL is broken") (parseBaseUrl "http://localhost:8002")
 
 options :: ParserInfo Config
 options =

--- a/holborn-syntax/lib/Holborn/Syntax/Scope.hs
+++ b/holborn-syntax/lib/Holborn/Syntax/Scope.hs
@@ -159,7 +159,7 @@ getBinding :: Symbol -> Environment a -> Maybe (Binding a)
 getBinding symbol env =
   case M.lookup symbol (definitions env) of
     Nothing -> Nothing
-    Just [] -> terror $ "Empty definition list for " ++ show symbol
+    Just [] -> error $ "Empty definition list for " <> show symbol
     Just (x:_) -> Just x
 
 


### PR DESCRIPTION
Just removes `terror` and replaces with `error`. There's one case where I replace it with `panic`.
