### PR TITLE
Drop 'id' export from prelude

### DIFF
--- a/holborn-prelude/lib/HolbornPrelude.hs
+++ b/holborn-prelude/lib/HolbornPrelude.hs
@@ -8,10 +8,6 @@ module HolbornPrelude
   ( -- * Module exports
     module Protolude
 
-    -- * Backwards compatibility
-    --
-    -- To make migrating to Protolude easier.
-  , id
     -- | Protolude doesn't export much String stuff, this is mostly a good
     -- thing, but we're going to export some String stuff to make our lives
     -- easier.
@@ -67,10 +63,6 @@ infixr 5 ++
 
 concat :: (Foldable t, Monoid a) => t a -> a
 concat = fold
-
-{-# DEPRECATED id "Use 'identity' instead" #-}
-id :: a -> a
-id = identity
 
 {-# DEPRECATED fromShow "Use 'show' instead" #-}
 fromShow :: (Show a, StringConv String b) => a -> b

--- a/holborn-repo/lib/Holborn/Repo/GitLayer.hs
+++ b/holborn-repo/lib/Holborn/Repo/GitLayer.hs
@@ -94,7 +94,7 @@ makeRepository = Repo
 -- XXX: Store "Repository" in Reader(T)
 withRepository :: Repository -> (Repository -> GitM IO a) -> ExceptT BrowseException IO a
 withRepository repo action =
-  bimapExceptT justBrowseException HolbornPrelude.id $ syncIO $ do
+  bimapExceptT justBrowseException identity $ syncIO $ do
     repoExists <- doesDirectoryExist (_repoPath repo)
     if repoExists
       then Git.withRepository' lgFactory options (action repo)

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,8 +11,8 @@ packages:
   - location:
       # double-conversion doesn't build on Darwin.
       # See https://github.com/bos/double-conversion/pull/14
-      git: https://github.com/bradediger/double-conversion.git
-      commit: fb8666ecccc303a4a48ced16a5fbd8d2e6e83e3e
+      git: https://github.com/jml/double-conversion.git
+      commit: 79c7c08abac06f164522f6a327dd3e044efcd922
     extra-dep: true
   - location:
       # pipes-shell doesn't work with ghc 8.0


### PR DESCRIPTION
Use `identity` instead. Can now use `id` as a variable.
